### PR TITLE
Replace deprecated getfuncargvalue with getfixturevalue

### DIFF
--- a/pytest_tornasync/plugin.py
+++ b/pytest_tornasync/plugin.py
@@ -86,7 +86,7 @@ def http_server(request, io_loop, http_server_port):
     Raises:
         FixtureLookupError: tornado application fixture not found
     """
-    http_app = request.getfuncargvalue(request.config.option.app_fixture)
+    http_app = request.getfixturevalue(request.config.option.app_fixture)
     server = tornado.httpserver.HTTPServer(http_app)
     server.add_socket(http_server_port[0])
 


### PR DESCRIPTION
Remove the following deprecation warning (with `pytest>=3.9`): `pytest_tornasync/plugin.py:89: RemovedInPytest4Warning: getfuncargvalue is deprecated, use getfixturevalue`

`getfuncargvalue` was renamed to `getfixturevalue` in pytest 3.0.0 ([pytest changelog](https://docs.pytest.org/en/latest/changelog.html#id562)) and has been deprecated since. As pytest-tornasync requires `pytest>=3.0`, I simply replaced the function name.