### PR TITLE
Include full tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+graft test
+include pytest.ini
+include tox.ini
+
+include *.rst


### PR DESCRIPTION
This allows downstream packagers to check their installation.